### PR TITLE
Document use of WeakReference by Presenter

### DIFF
--- a/mortar/src/main/java/mortar/Presenter.java
+++ b/mortar/src/main/java/mortar/Presenter.java
@@ -36,6 +36,8 @@ public abstract class Presenter<V> implements Bundler {
    * <p/>
    * This presenter will be immediately {@link MortarActivityScope#register registered} (or
    * re-registered), leading to an immediate call to {@link #onLoad}
+   * <p/>
+   * The presenter will retain the view in a {@link WeakReference}.
    *
    * @see MortarActivityScope#register
    */
@@ -55,7 +57,10 @@ public abstract class Presenter<V> implements Bundler {
     return view.get();
   }
 
-  /** Called to surrender control of this view, e.g. when a dialog is dismissed. */
+  /**
+   * Called to explicitly surrender control of this view, e.g. when a dialog is
+   * dismissed.
+   */
   protected final void dropView() {
     view.clear();
   }


### PR DESCRIPTION
That Presenter holds its view in a WeakReference is a significant part
of its contract.
