### PR TITLE
Creating good looking scope hierarchies

### DIFF
--- a/mortar/src/main/java/mortar/MortarScopeDevHelper.java
+++ b/mortar/src/main/java/mortar/MortarScopeDevHelper.java
@@ -1,40 +1,63 @@
 package mortar;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 public class MortarScopeDevHelper {
 
   /** Format the scope hierarchy as a multi line string containing the scope names. */
   public static String scopeHierarchyToString(MortarScope mortarScope) {
     StringBuilder result = new StringBuilder();
-    scopeHierarchyToString(result, 0, mortarScope);
+    scopeHierarchyToString(result, 0, 0, mortarScope);
     return result.toString();
   }
 
-  private static void scopeHierarchyToString(StringBuilder result, int depth,
+  private static void scopeHierarchyToString(StringBuilder result, int depth, long lastChildMask,
       MortarScope mortarScope) {
-    if (depth > 1) {
-      result.append(String.format("%" + (depth - 1) + "s", " ").replaceAll(" ", "| "));
+
+    int lastDepth = depth - 1;
+    for (int parentDepth = 0; parentDepth <= lastDepth; parentDepth++) {
+      if (parentDepth > 0) {
+        result.append(' ');
+      }
+      boolean lastChild = (lastChildMask & (1 << parentDepth)) != 0;
+      if (lastChild) {
+        if (parentDepth == lastDepth) {
+          result.append('\\');
+        } else {
+          result.append(' ');
+        }
+      } else {
+        if (parentDepth == lastDepth) {
+          result.append('+');
+        } else {
+          result.append("| ");
+        }
+      }
     }
     if (depth > 0) {
-      result.append("|-");
+      result.append("- ");
     }
     result.append(mortarScope.getName());
     result.append('\n');
 
-    for (MortarScope childScope : getScopeChildren(mortarScope)) {
-      scopeHierarchyToString(result, depth + 1, childScope);
+    Collection<MortarScope> children = getScopeChildren(mortarScope);
+    int lastIndex = children.size() - 1;
+    int index = 0;
+    for (MortarScope childScope : children) {
+      if (index == lastIndex) {
+        lastChildMask = lastChildMask | (1 << depth);
+      }
+      scopeHierarchyToString(result, depth + 1, lastChildMask, childScope);
+      index++;
     }
   }
 
-  private static List<MortarScope> getScopeChildren(MortarScope mortarScope) {
+  private static Collection<MortarScope> getScopeChildren(MortarScope mortarScope) {
     if (!(mortarScope instanceof RealMortarScope)) {
       return Collections.emptyList();
     }
-
     RealMortarScope realMortarScope = (RealMortarScope) mortarScope;
-    return new ArrayList<MortarScope>(realMortarScope.children.values());
+    return Collections.<MortarScope>unmodifiableCollection(realMortarScope.children.values());
   }
 }

--- a/mortar/src/test/java/mortar/MortarScopeDevHelperTest.java
+++ b/mortar/src/test/java/mortar/MortarScopeDevHelperTest.java
@@ -1,0 +1,66 @@
+package mortar;
+
+import dagger.ObjectGraph;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class MortarScopeDevHelperTest {
+
+  class CustomScope implements Blueprint {
+
+    private final String name;
+
+    CustomScope(String name) {
+      this.name = name;
+    }
+
+    @Override public String getMortarScopeName() {
+      return name;
+    }
+
+    @Override public Object getDaggerModule() {
+      return this;
+    }
+  }
+
+  @Mock ObjectGraph graph;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    when(graph.plus(any())).thenReturn(graph);
+  }
+
+  @Test public void nestedScopeHierarchyToString() {
+    MortarScope root = Mortar.createRootScope(false, graph);
+    MortarScope elder = root.requireChild(new CustomScope("Elder"));
+    elder.requireChild(new CustomScope("ElderElder"));
+    elder.requireChild(new CustomScope("ElderCadet"));
+    root.requireChild(new CustomScope("Cadet"));
+
+    String hierarchy = MortarScopeDevHelper.scopeHierarchyToString(root);
+
+    /*
+        Here is what it should look like:
+
+        Root
+        +- Elder
+        |  +- ElderElder
+        |  \- ElderCadet
+        \- Cadet
+     */
+
+    assertThat(hierarchy).isEqualTo("" //
+        + "Root\n" //
+        + "+- Elder\n" //
+        + "|  +- ElderElder\n" //
+        + "|  \\- ElderCadet\n" //
+        + "\\- Cadet\n");
+  }
+}


### PR DESCRIPTION
Improved the dev string output of the scope hierarchy to look good. I used `maven dependency:tree` as a model.

```
Root
+- Elder
|  +- ElderElder
|  \- ElderCadet
\- Cadet
```
