### PR TITLE
Eager calls to takeView()

### DIFF
--- a/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
@@ -32,8 +32,8 @@ public class MainView extends FlowOwnerView<Blueprint> {
     Mortar.inject(context, this);
   }
 
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
+  @Override protected void onFinishInflate() {
+    super.onFinishInflate();
     presenter.takeView(this);
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/util/FlowOwnerView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/util/FlowOwnerView.java
@@ -16,9 +16,7 @@
 package com.example.mortar.util;
 
 import android.content.Context;
-import android.os.Parcelable;
 import android.util.AttributeSet;
-import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -46,11 +44,8 @@ import static android.view.animation.AnimationUtils.loadAnimation;
  */
 public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
 
-  private SparseArray<Parcelable> lastRestoredHierarchyState;
-
   public FlowOwnerView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    Mortar.inject(context, this);
   }
 
   public void showScreen(S screen, Flow.Direction direction) {
@@ -80,12 +75,6 @@ public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
     ViewGroup container = getContainer();
     if (oldChild != null) container.removeView(oldChild);
     container.addView(newChild);
-
-    // Restore view state.
-    if (lastRestoredHierarchyState != null) {
-      newChild.restoreHierarchyState(lastRestoredHierarchyState);
-      lastRestoredHierarchyState = null;
-    }
   }
 
   protected void setAnimation(Flow.Direction direction, View oldChild, View newChild) {
@@ -96,14 +85,6 @@ public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
 
     oldChild.setAnimation(loadAnimation(getContext(), out));
     newChild.setAnimation(loadAnimation(getContext(), in));
-  }
-
-  @Override public void restoreHierarchyState(SparseArray<Parcelable> container) {
-    // This is called before revived instances are told what child to show, so save the
-    // container for later.
-
-    lastRestoredHierarchyState = container;
-    super.restoreHierarchyState(container);
   }
 
   public boolean onBackPressed() {

--- a/mortar-sample/src/main/java/com/example/mortar/view/ChatListView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/view/ChatListView.java
@@ -34,10 +34,6 @@ public class ChatListView extends ListView {
   public ChatListView(Context context, AttributeSet attrs) {
     super(context, attrs);
     Mortar.inject(context, this);
-  }
-
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
     presenter.takeView(this);
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/view/ChatView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/view/ChatView.java
@@ -40,10 +40,6 @@ public class ChatView extends ListView {
     confirmerPopup = new ConfirmerPopup(context);
 
     setTranscriptMode(ListView.TRANSCRIPT_MODE_NORMAL);
-  }
-
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
     presenter.takeView(this);
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/view/FriendListView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/view/FriendListView.java
@@ -34,10 +34,6 @@ public class FriendListView extends ListView {
   public FriendListView(Context context, AttributeSet attrs) {
     super(context, attrs);
     Mortar.inject(context, this);
-  }
-
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
     presenter.takeView(this);
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/view/FriendView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/view/FriendView.java
@@ -29,10 +29,6 @@ public class FriendView extends TextView  {
   public FriendView(Context context, AttributeSet attrs) {
     super(context, attrs);
     Mortar.inject(context, this);
-  }
-
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
     presenter.takeView(this);
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/view/MessageView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/view/MessageView.java
@@ -43,10 +43,6 @@ public class MessageView extends LinearLayout {
   @Override protected void onFinishInflate() {
     super.onFinishInflate();
     Views.inject(this);
-  }
-
-  @Override protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
     presenter.takeView(this);
   }
 

--- a/mortar/src/main/java/mortar/Presenter.java
+++ b/mortar/src/main/java/mortar/Presenter.java
@@ -21,15 +21,15 @@ public abstract class Presenter<V> implements Bundler {
   private V view = null;
 
   /**
-   * Called to give this presenter control of a view. Do not call this from the view's
-   * constructor. Instead call it after construction when the view is known to be going
-   * live, e.g. from {@link android.view.View#onAttachedToWindow()} or from
-   * {@link android.app.Activity#onCreate}.
+   * Called to give this presenter control of a view. Call it when the view is known to be going
+   * live, e.g. from {@link android.app.Activity#onCreate} for an activity, {@link
+   * android.view.View#onFinishInflate()} for a view created through inflation, or in the view
+   * constructor otherwise.
    * <p/>
    * This presenter will be immediately {@link MortarActivityScope#register registered} (or
    * re-registered), leading to an immediate call to {@link #onLoad}. It is expected that
    * {@link #dropView(Object)} will be called with the same argument when the view is
-   * no longer active, e.g. from {@link android.view.View#onAttachedToWindow()} or from
+   * no longer active, e.g. from {@link android.view.View#onDetachedFromWindow()} or from
    * {@link android.app.Activity#onDestroy()}.
    *
    * @see MortarActivityScope#register


### PR DESCRIPTION
Views shouldn't wait for the onAttachToWindow() callback to call Presenter.takeView(). The presentation logic and the view hierarchy should all be loaded (based on saved instance state) when onCreate() is done.

This PR:
- moves the calls from onAttachToWindow() to either View.onFinishInflate() (in case of an inflated view group), or in the view constructor.
- Also removed `Mortar.inject(getContext(), this);` from `FlowOwnerView`. It's already done in its subclass `MainView`. I wasn't sure where to keep it, but `FlowOwnerView` doesn't have any injects so...
- FlowOwnerView doesn't need to keep `lastRestoredHierarchyState` around anymore. Yey!

**DO NOT MERGE**

As per `mortar.MortarActivityScope#register` documentation:

```
/**
 * Registers the given to have its {@link Scoped#onDestroy()} method called. In addition,
 * if it is an instance of {@link Bundler}:
 * <ul>
 * <li>{@link Bundler#onLoad} is called immediately</li>
 * <li>{@link Bundler#onLoad} is also called from {@link android.app.Activity#onResume()}
 * <li>{@link Bundler#onSave} is called from {@link android.app.Activity#onSaveInstanceState}
 * </ul>
 * Note well that calls to onLoad and onSave are not symmetric: it is par for the course to
 * receive redundant onLoad calls.
 */
  @Override void register(Scoped s);
```

This leads to a double call to Bundle.onLoad() on presenters, which means we're doing unnecessary work. It wasn't a problem before because that onLoad call would happen when the views where not taken by the presenter yet. So the double call was "useful" in that case (kinda meh though).

Now, is there any other good reason for calling Bundler#onLoad from Activity#onResume?

If not, then I suggest we just remove that behavior. If yes, we'll need to prevent that double call. Loading a presenter from onResume() is wrong anyway.
