### PR TITLE
Favor delegation over composition

### DIFF
--- a/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
+++ b/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
@@ -17,7 +17,6 @@ package com.example.mortar;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.ViewGroup;
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockActivity;
 import com.actionbarsherlock.view.Menu;
@@ -25,6 +24,7 @@ import com.actionbarsherlock.view.MenuItem;
 import com.example.mortar.android.ActionBarOwner;
 import com.example.mortar.core.Main;
 import com.example.mortar.core.MainView;
+import flow.Flow;
 import javax.inject.Inject;
 import mortar.Mortar;
 import mortar.MortarActivityScope;
@@ -45,6 +45,7 @@ public class DemoActivity extends SherlockActivity implements MortarContext, Act
   private ActionBarOwner.MenuAction actionBarMenuAction;
 
   @Inject ActionBarOwner actionBarOwner;
+  private Flow mainFlow;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -60,6 +61,8 @@ public class DemoActivity extends SherlockActivity implements MortarContext, Act
 
     activityScope.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+    MainView mainView = (MainView) findViewById(R.id.container);
+    mainFlow = mainView.getFlow();
 
     actionBarOwner.takeView(this);
   }
@@ -72,15 +75,13 @@ public class DemoActivity extends SherlockActivity implements MortarContext, Act
   /** Inform the view about back events. */
   @Override public void onBackPressed() {
     // Give the view a chance to handle going back. If it declines the honor, let super do its thing.
-    MainView view = getMainView();
-    if (!view.onBackPressed()) super.onBackPressed();
+    if (!mainFlow.goBack()) super.onBackPressed();
   }
 
   /** Inform the view about up events. */
   @Override public boolean onOptionsItemSelected(MenuItem item) {
     if (item.getItemId() == android.R.id.home) {
-      MainView view = getMainView();
-      return view.onUpPressed();
+      return mainFlow.goUp();
     }
 
     return super.onOptionsItemSelected(item);
@@ -106,6 +107,7 @@ public class DemoActivity extends SherlockActivity implements MortarContext, Act
 
     actionBarOwner.dropView(this);
 
+    // activityScope may be null in case isWrongInstance() returned true in onCreate()
     if (isFinishing() && activityScope != null) {
       activityScope.destroy();
       activityScope = null;
@@ -147,10 +149,5 @@ public class DemoActivity extends SherlockActivity implements MortarContext, Act
       return intent.hasCategory(CATEGORY_LAUNCHER) && isMainAction;
     }
     return false;
-  }
-
-  private MainView getMainView() {
-    ViewGroup root = (ViewGroup) findViewById(android.R.id.content);
-    return (MainView) root.getChildAt(0);
   }
 }

--- a/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
@@ -17,31 +17,34 @@ package com.example.mortar.core;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.ViewGroup;
-import com.example.mortar.util.FlowOwner;
-import com.example.mortar.util.FlowOwnerView;
+import android.widget.FrameLayout;
+import com.example.mortar.util.CanShowScreen;
+import com.example.mortar.util.ScreenConductor;
+import flow.Flow;
 import javax.inject.Inject;
 import mortar.Blueprint;
 import mortar.Mortar;
 
-public class MainView extends FlowOwnerView<Blueprint> {
+public class MainView extends FrameLayout implements CanShowScreen<Blueprint> {
   @Inject Main.Presenter presenter;
+  private final ScreenConductor<Blueprint> screenMaestro;
 
   public MainView(Context context, AttributeSet attrs) {
     super(context, attrs);
     Mortar.inject(context, this);
+    screenMaestro = new ScreenConductor<Blueprint>(context, this);
   }
 
   @Override protected void onFinishInflate() {
     super.onFinishInflate();
-    getPresenter().takeView(this);
+    presenter.takeView(this);
   }
 
-  @Override protected ViewGroup getContainer() {
-    return this;
+  public Flow getFlow() {
+    return presenter.getFlow();
   }
 
-  @Override protected FlowOwner<Blueprint, MainView> getPresenter() {
-    return presenter;
+  @Override public void showScreen(Blueprint screen, Flow.Direction direction) {
+    screenMaestro.showScreen(screen, direction);
   }
 }

--- a/mortar-sample/src/main/java/com/example/mortar/util/CanShowScreen.java
+++ b/mortar-sample/src/main/java/com/example/mortar/util/CanShowScreen.java
@@ -1,0 +1,8 @@
+package com.example.mortar.util;
+
+import flow.Flow;
+import mortar.Blueprint;
+
+public interface CanShowScreen<S extends Blueprint> {
+  void showScreen(S screen, Flow.Direction direction);
+}

--- a/mortar-sample/src/main/java/com/example/mortar/util/FlowOwner.java
+++ b/mortar-sample/src/main/java/com/example/mortar/util/FlowOwner.java
@@ -16,6 +16,7 @@
 package com.example.mortar.util;
 
 import android.os.Bundle;
+import android.view.View;
 import flow.Backstack;
 import flow.Flow;
 import flow.Parcer;
@@ -23,7 +24,7 @@ import mortar.Blueprint;
 import mortar.ViewPresenter;
 
 /** Base class for all presenters that manage a {@link flow.Flow}. */
-public abstract class FlowOwner<S extends Blueprint, V extends FlowOwnerView<S>>
+public abstract class FlowOwner<S extends Blueprint, V extends View & CanShowScreen<S>>
     extends ViewPresenter<V> implements Flow.Listener {
 
   private static final String FLOW_KEY = "FLOW_KEY";

--- a/mortar-sample/src/main/java/com/example/mortar/util/ScreenConductor.java
+++ b/mortar-sample/src/main/java/com/example/mortar/util/ScreenConductor.java
@@ -16,10 +16,8 @@
 package com.example.mortar.util;
 
 import android.content.Context;
-import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
 import com.example.mortar.R;
 import flow.Flow;
 import flow.Layouts;
@@ -30,28 +28,28 @@ import mortar.MortarScope;
 import static android.view.animation.AnimationUtils.loadAnimation;
 
 /**
- * A parent view that displays subviews within a {@link #getContainer() container view}.
+ * A conductor that can swap subviews within a container view.
  * <p/>
- * Like all Mortar views, subclasses must call {@link mortar.ViewPresenter#takeView},
- * typically from {@link #onFinishInflate()}. E.g.
- * <code><pre>
- *{@literal @}Override protected void onFinishInflate() {
- *   super.onFinishInflate();
- *   getPresenter().takeView(this);
- * }</pre></code>
  *
  * @param <S> the type of the screens that serve as a {@link Blueprint} for subview. Must
  * be annotated with {@link flow.Layout}, suitable for use with {@link flow.Layouts#createView}.
  */
-public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
+public class ScreenConductor<S extends Blueprint> implements CanShowScreen<S> {
 
-  public FlowOwnerView(Context context, AttributeSet attrs) {
-    super(context, attrs);
-    Mortar.inject(context, this);
+  private final Context context;
+  private final ViewGroup container;
+
+  /**
+   * @param container the container used to host child views. Typically this is a {@link
+   * android.widget.FrameLayout} under the action bar.
+   */
+  public ScreenConductor(Context context, ViewGroup container) {
+    this.context = context;
+    this.container = container;
   }
 
   public void showScreen(S screen, Flow.Direction direction) {
-    MortarScope myScope = Mortar.getScope(getContext());
+    MortarScope myScope = Mortar.getScope(context);
     MortarScope newChildScope = myScope.requireChild(screen);
 
     View oldChild = getChildView();
@@ -68,13 +66,12 @@ public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
     }
 
     // Create the new child.
-    Context childContext = newChildScope.createContext(getContext());
+    Context childContext = newChildScope.createContext(context);
     newChild = Layouts.createView(childContext, screen);
 
     setAnimation(direction, oldChild, newChild);
 
     // Out with the old, in with the new.
-    ViewGroup container = getContainer();
     if (oldChild != null) container.removeView(oldChild);
     container.addView(newChild);
   }
@@ -85,31 +82,11 @@ public abstract class FlowOwnerView<S extends Blueprint> extends FrameLayout {
     int out = direction == Flow.Direction.FORWARD ? R.anim.slide_out_left : R.anim.slide_out_right;
     int in = direction == Flow.Direction.FORWARD ? R.anim.slide_in_right : R.anim.slide_in_left;
 
-    oldChild.setAnimation(loadAnimation(getContext(), out));
-    newChild.setAnimation(loadAnimation(getContext(), in));
+    oldChild.setAnimation(loadAnimation(context, out));
+    newChild.setAnimation(loadAnimation(context, in));
   }
-
-  public boolean onBackPressed() {
-    return getPresenter().onRetreatSelected();
-  }
-
-  public boolean onUpPressed() {
-    return getPresenter().onUpSelected();
-  }
-
-  /**
-   * Return the container used to host child views. Typically this is a {@link
-   * android.widget.FrameLayout} under the action bar.
-   */
-  protected abstract ViewGroup getContainer();
-
-  /**
-   * Return the {@link FlowOwner} that manages this view. Remember that subclasses
-   * can refine the type returned by this method.
-   */
-  protected abstract FlowOwner<? extends Blueprint, ?> getPresenter();
 
   private View getChildView() {
-    return getContainer().getChildAt(0);
+    return container.getChildAt(0);
   }
 }


### PR DESCRIPTION
- Renaming FlowOwnerView to ScreenConductor. It's not a specific view anymore (frame layout or whatever) and could be reused for any kind of container. This enables easily using several flow owners.
- Introducing CanShowScreen which has to be implemented by the flow view. Most likely you'll just want to delegate to a ScreenConductor, but you could also do your own thing.
- DemoActivity directly accesses the main flow instead of the boilerplate calls to up / back (with different names each time)
- Got rid of the weird retrieval code for MainView. Don't do this.
