### PR TITLE
Dev: print scopes, dagger modules & entry points

### DIFF
--- a/mortar/src/main/java/mortar/MortarScopeDevHelper.java
+++ b/mortar/src/main/java/mortar/MortarScopeDevHelper.java
@@ -1,21 +1,196 @@
 package mortar;
 
-import java.util.Collection;
+import dagger.ObjectGraph;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class MortarScopeDevHelper {
 
-  /** Format the scope hierarchy as a multi line string containing the scope names. */
+  /**
+   * Format the scope hierarchy as a multi line string containing the scope names.
+   * Can be given any scope in the hierarchy, will always print the whole scope hierarchy.
+   * Also prints the Dagger modules containing entry points (injects). We've only tested this with
+   * Dagger 1.1.0, please report any bug you may find.
+   */
   public static String scopeHierarchyToString(MortarScope mortarScope) {
-    StringBuilder result = new StringBuilder();
-    scopeHierarchyToString(result, 0, 0, mortarScope);
+    StringBuilder result = new StringBuilder("Mortar Hierarchy:\n");
+    MortarScope rootScope = getRootScope(mortarScope);
+    Node rootNode = new MortarScopeNode(rootScope);
+    nodeHierarchyToString(result, 0, 0, rootNode);
     return result.toString();
   }
 
-  private static void scopeHierarchyToString(StringBuilder result, int depth, long lastChildMask,
-      MortarScope mortarScope) {
+  interface Node {
+    String getName();
 
+    List<Node> getChildNodes();
+  }
+
+  static class MortarScopeNode implements Node {
+
+    private final MortarScope mortarScope;
+
+    MortarScopeNode(MortarScope mortarScope) {
+      this.mortarScope = mortarScope;
+    }
+
+    @Override public String getName() {
+      return "SCOPE " + mortarScope.getName();
+    }
+
+    @Override public List<Node> getChildNodes() {
+      List<Node> childNodes = new ArrayList<Node>();
+      ModuleNode.addModuleChildren(mortarScope, childNodes);
+      addScopeChildren(childNodes);
+      return childNodes;
+    }
+
+    private void addScopeChildren(List<Node> childNodes) {
+      if (!(mortarScope instanceof RealMortarScope)) {
+        return;
+      }
+      RealMortarScope realMortarScope = (RealMortarScope) mortarScope;
+      for (MortarScope childScope : realMortarScope.children.values()) {
+        childNodes.add(new MortarScopeNode(childScope));
+      }
+    }
+  }
+
+  static class ModuleNode implements Node {
+
+    private static Class<?> OBJECT_GRAPH_CLASS;
+    private static Field INJECTABLE_TYPES_FIELD;
+    private static boolean COULD_NOT_LOAD;
+
+    static {
+      try {
+        OBJECT_GRAPH_CLASS = Class.forName("dagger.ObjectGraph$DaggerObjectGraph");
+        INJECTABLE_TYPES_FIELD = OBJECT_GRAPH_CLASS.getDeclaredField("injectableTypes");
+        INJECTABLE_TYPES_FIELD.setAccessible(true);
+      } catch (Exception e) {
+        COULD_NOT_LOAD = true;
+      }
+    }
+
+    static void addModuleChildren(MortarScope mortarScope, List<Node> childNodes) {
+      if (COULD_NOT_LOAD) {
+        childNodes.add(new Node() {
+          @Override public String getName() {
+            return "ERROR Could not access Dagger fields";
+          }
+
+          @Override public List<Node> getChildNodes() {
+            return Collections.emptyList();
+          }
+        });
+        return;
+      }
+
+      ObjectGraph objectGraph = mortarScope.getObjectGraph();
+
+      if (!OBJECT_GRAPH_CLASS.isInstance(objectGraph)) {
+        throw new IllegalArgumentException(
+            objectGraph + " is not an instance of " + OBJECT_GRAPH_CLASS);
+      }
+
+      Map<String, Class<?>> injectableTypes;
+
+      try {
+        //noinspection unchecked
+        injectableTypes = (Map<String, Class<?>>) INJECTABLE_TYPES_FIELD.get(objectGraph);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      // Mapping Map<Inject, Module> to Map<Module, List<Inject>>
+      Map<Class<?>, List<Node>> injectsByModule = new HashMap<Class<?>, List<Node>>();
+      for (Map.Entry<String, Class<?>> injectableType : injectableTypes.entrySet()) {
+        Class<?> moduleClass = injectableType.getValue();
+        List<Node> moduleInjects = injectsByModule.get(moduleClass);
+        if (moduleInjects == null) {
+          moduleInjects = new ArrayList<Node>();
+          injectsByModule.put(moduleClass, moduleInjects);
+        }
+        moduleInjects.add(new InjectNode(injectableType.getKey()));
+      }
+
+      Set<Map.Entry<Class<?>, List<Node>>> injectsByModuleSet = injectsByModule.entrySet();
+      for (Map.Entry<Class<?>, List<Node>> moduleAndInjects : injectsByModuleSet) {
+        childNodes.add(new ModuleNode(moduleAndInjects.getKey(), moduleAndInjects.getValue()));
+      }
+    }
+
+    private final Class<?> moduleClass;
+    private final List<Node> injects;
+
+    ModuleNode(Class<?> moduleClass, List<Node> injects) {
+      this.moduleClass = moduleClass;
+      this.injects = injects;
+    }
+
+    @Override public String getName() {
+      return "MODULE " + moduleClass.getName();
+    }
+
+    @Override public List<Node> getChildNodes() {
+      return injects;
+    }
+  }
+
+  static class InjectNode implements Node {
+    private static final int MEMBER_PREFIX = "members/".length();
+
+    private final String name;
+
+    InjectNode(String moduleMember) {
+      // Inject keys name starts with "members/" which we don't care about.
+      this.name = "INJECT " + moduleMember.substring(MEMBER_PREFIX);
+    }
+
+    @Override public String getName() {
+      return name;
+    }
+
+    @Override public List<Node> getChildNodes() {
+      return Collections.emptyList();
+    }
+  }
+
+  private static MortarScope getRootScope(MortarScope mortarScope) {
+    if (!(mortarScope instanceof RealMortarScope)) {
+      return mortarScope;
+    }
+    RealMortarScope scope = (RealMortarScope) mortarScope;
+    while (scope.getParent() != null) {
+      scope = scope.getParent();
+    }
+    return scope;
+  }
+
+  private static void nodeHierarchyToString(StringBuilder result, int depth, long lastChildMask,
+      Node node) {
+    appendLinePrefix(result, depth, lastChildMask);
+    result.append(node.getName()).append('\n');
+    List<Node> childNodes = node.getChildNodes();
+    int lastIndex = childNodes.size() - 1;
+    int index = 0;
+    for (Node childNode : childNodes) {
+      if (index == lastIndex) {
+        lastChildMask = lastChildMask | (1 << depth);
+      }
+      nodeHierarchyToString(result, depth + 1, lastChildMask, childNode);
+      index++;
+    }
+  }
+
+  private static void appendLinePrefix(StringBuilder result, int depth, long lastChildMask) {
     int lastDepth = depth - 1;
+    // Add a non-breaking space at the beginning of the line because Logcat eats normal spaces.
+    result.append('\u00a0');
     for (int parentDepth = 0; parentDepth <= lastDepth; parentDepth++) {
       if (parentDepth > 0) {
         result.append(' ');
@@ -23,7 +198,7 @@ public class MortarScopeDevHelper {
       boolean lastChild = (lastChildMask & (1 << parentDepth)) != 0;
       if (lastChild) {
         if (parentDepth == lastDepth) {
-          result.append('\\');
+          result.append('`');
         } else {
           result.append(' ');
         }
@@ -31,33 +206,16 @@ public class MortarScopeDevHelper {
         if (parentDepth == lastDepth) {
           result.append('+');
         } else {
-          result.append("| ");
+          result.append('|');
         }
       }
     }
     if (depth > 0) {
-      result.append("- ");
-    }
-    result.append(mortarScope.getName());
-    result.append('\n');
-
-    Collection<MortarScope> children = getScopeChildren(mortarScope);
-    int lastIndex = children.size() - 1;
-    int index = 0;
-    for (MortarScope childScope : children) {
-      if (index == lastIndex) {
-        lastChildMask = lastChildMask | (1 << depth);
-      }
-      scopeHierarchyToString(result, depth + 1, lastChildMask, childScope);
-      index++;
+      result.append("-");
     }
   }
 
-  private static Collection<MortarScope> getScopeChildren(MortarScope mortarScope) {
-    if (!(mortarScope instanceof RealMortarScope)) {
-      return Collections.emptyList();
-    }
-    RealMortarScope realMortarScope = (RealMortarScope) mortarScope;
-    return Collections.<MortarScope>unmodifiableCollection(realMortarScope.children.values());
+  private MortarScopeDevHelper() {
+    throw new UnsupportedOperationException("This is a helper class");
   }
 }

--- a/mortar/src/main/java/mortar/RealActivityScope.java
+++ b/mortar/src/main/java/mortar/RealActivityScope.java
@@ -36,7 +36,7 @@ class RealActivityScope extends RealMortarScope implements MortarActivityScope {
   private Set<Bundler> bundlers = new HashSet<Bundler>();
 
   RealActivityScope(RealMortarScope original) {
-    super(original.getName(), ((RealMortarScope) original.getParent()), original.validate,
+    super(original.getName(), original.getParent(), original.validate,
         original.getObjectGraph());
   }
 

--- a/mortar/src/main/java/mortar/RealMortarScope.java
+++ b/mortar/src/main/java/mortar/RealMortarScope.java
@@ -75,7 +75,7 @@ class RealMortarScope implements MortarScope {
     tearDowns.add(scoped);
   }
 
-  MortarScope getParent() {
+  RealMortarScope getParent() {
     return parent;
   }
 


### PR DESCRIPTION
- Using reflection to read into Dagger object graph
- Dagger keeps a Map<Inject, Module>. We transform that back into a Map<Module, List<Inject>>
- Using `\u00a0` (non-breaking space) as a first line char, because Logcat hates white spaces
- Using backquotes for last child (you were right @jw, it looks better)
- Splitting the code for "printing a tree" from the one that transforms scopes, modules and injects into nodes.
- Moar tests

```
Mortar Hierarchy:
SCOPE Root
+-MODULE com.example.mortar.model.Chats.Module
| `-INJECT com.example.mortar.model.Chats
`-SCOPE com.example.mortar.core.Main
  +-MODULE com.example.mortar.core.Main.Module
  | `-INJECT com.example.mortar.core.MainView
  +-MODULE com.example.mortar.android.ActionBarModule
  | `-INJECT com.example.mortar.DemoActivity
  `-SCOPE com.example.mortar.screen.ChatListScreen
    `-MODULE com.example.mortar.screen.ChatListScreen.Module
      `-INJECT com.example.mortar.view.ChatListView
```
