### PR TITLE
Child scope created during register() get state

### DIFF
--- a/mortar/src/main/java/mortar/RealActivityScope.java
+++ b/mortar/src/main/java/mortar/RealActivityScope.java
@@ -130,7 +130,7 @@ class RealActivityScope extends RealMortarScope implements MortarActivityScope {
     RealActivityScope childScope =
         new RealActivityScope((RealMortarScope) unwrapped, loadingFromOnCreate);
     replaceChild(blueprint.getMortarScopeName(), childScope);
-    if (loadingState != LoadingState.LOADING) {
+    if (!loadingFromOnCreate) {
       childScope.onCreate(getChildBundle(childScope, latestSavedInstanceState, false));
     }
     return childScope;


### PR DESCRIPTION
Fix for #53.

When requiring a child scope, we only skip calling onCreate() on the child scope if we are in an onCreate() loading.
