### PR TITLE
Alphabetize the Dev Scope ordering

### DIFF
--- a/mortar/src/main/java/mortar/MortarScopeDevHelper.java
+++ b/mortar/src/main/java/mortar/MortarScopeDevHelper.java
@@ -4,6 +4,7 @@ import dagger.ObjectGraph;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,7 +176,10 @@ public class MortarScopeDevHelper {
       Node node) {
     appendLinePrefix(result, depth, lastChildMask);
     result.append(node.getName()).append('\n');
+
     List<Node> childNodes = node.getChildNodes();
+    Collections.sort(childNodes, new NodeSorter());
+
     int lastIndex = childNodes.size() - 1;
     int index = 0;
     for (Node childNode : childNodes) {
@@ -217,5 +221,11 @@ public class MortarScopeDevHelper {
 
   private MortarScopeDevHelper() {
     throw new UnsupportedOperationException("This is a helper class");
+  }
+
+  private static class NodeSorter implements Comparator<Node> {
+    @Override public int compare(Node lhs, Node rhs) {
+      return lhs.getName().compareTo(rhs.getName());
+    }
   }
 }

--- a/mortar/src/test/java/mortar/MortarScopeDevHelperTest.java
+++ b/mortar/src/test/java/mortar/MortarScopeDevHelperTest.java
@@ -24,11 +24,9 @@ import static mortar.MortarScopeDevHelper.scopeHierarchyToString;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class MortarScopeDevHelperTest {
-
   private static final char BLANK = '\u00a0';
 
   class CustomScope implements Blueprint {
-
     private final String name;
     private Object module;
 
@@ -67,20 +65,32 @@ public class MortarScopeDevHelperTest {
 
   @Test public void nestedScopeHierarchyToString() {
     MortarScope root = createRootScope(false, emptyObjectGraph());
-    MortarScope elder = root.requireChild(new CustomScope("Elder"));
-    elder.requireChild(new CustomScope("ElderElder"));
-    elder.requireChild(new CustomScope("ElderCadet"));
     root.requireChild(new CustomScope("Cadet"));
 
-    String hierarchy = scopeHierarchyToString(root);
+    MortarScope colonel = root.requireChild(new CustomScope("Colonel"));
+    colonel.requireChild(new CustomScope("ElderColonel"));
+    colonel.requireChild(new CustomScope("ZeElderColonel"));
 
+    MortarScope elder = root.requireChild(new CustomScope("Elder"));
+    elder.requireChild(new CustomScope("ElderCadet"));
+    elder.requireChild(new CustomScope("ZeElderCadet"));
+    elder.requireChild(new CustomScope("ElderElder"));
+    elder.requireChild(new CustomScope("AnElderCadet"));
+
+
+    String hierarchy = scopeHierarchyToString(root);
     assertThat(hierarchy).isEqualTo("" //
         + "Mortar Hierarchy:\n" //
         + BLANK + "SCOPE Root\n" //
-        + BLANK + "+-SCOPE Elder\n" //
-        + BLANK + "| +-SCOPE ElderElder\n" //
-        + BLANK + "| `-SCOPE ElderCadet\n" //
-        + BLANK + "`-SCOPE Cadet\n" //
+        + BLANK + "+-SCOPE Cadet\n" //
+        + BLANK + "+-SCOPE Colonel\n" //
+        + BLANK + "| +-SCOPE ElderColonel\n" //
+        + BLANK + "| `-SCOPE ZeElderColonel\n" //
+        + BLANK + "`-SCOPE Elder\n" //
+        + BLANK + "  +-SCOPE AnElderCadet\n" //
+        + BLANK + "  +-SCOPE ElderCadet\n" //
+        + BLANK + "  +-SCOPE ElderElder\n" //
+        + BLANK + "  `-SCOPE ZeElderCadet\n" //
     );
   }
 


### PR DESCRIPTION
Relying on the default ordering doesn't seem to jazz w/ Java 8
