### PR TITLE
Use getSystemService() to get the activity scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Change Log
 Next Version *TBD*
 ------------------
   * API break: MortarContext has been removed.  Activities must be careful to
-    construct and use a Mortar context; see the samples.  This change allows
+    override getSystemService(); see the samples. This change allows
     Mortar to coexist peacefully with other ContextWrappers.
 
 Version 0.11 *(2014-04-03)*

--- a/mortar-helloworld/src/main/java/com/example/hellomortar/HelloActivity.java
+++ b/mortar-helloworld/src/main/java/com/example/hellomortar/HelloActivity.java
@@ -16,41 +16,30 @@
 package com.example.hellomortar;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 import mortar.Mortar;
 import mortar.MortarActivityScope;
 import mortar.MortarScope;
 
 public class HelloActivity extends Activity {
   private MortarActivityScope activityScope;
-  private Context mortarContext;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     MortarScope parentScope = ((HelloApplication) getApplication()).getRootScope();
     activityScope = Mortar.requireActivityScope(parentScope, new Main());
-    mortarContext = activityScope.createContext(this);
-    Mortar.inject(mortarContext, this);
+    Mortar.inject(this, this);
     activityScope.onCreate(savedInstanceState);
-
-    ViewGroup content = (ViewGroup) findViewById(android.R.id.content);
-    View currentView = content.getChildAt(0);
-    if (currentView != null) {
-      throw new AssertionError("oops");
-    }
 
     setContentView(R.layout.main_view);
   }
 
-  @Override public void setContentView(int layoutResID) {
-    LayoutInflater inflater
-        = (LayoutInflater) mortarContext.getSystemService(LAYOUT_INFLATER_SERVICE);
-    inflater.inflate(layoutResID, (ViewGroup) findViewById(android.R.id.content));
+  @Override public Object getSystemService(String name) {
+    if (Mortar.isScopeSystemService(name)) {
+      return activityScope;
+    }
+    return super.getSystemService(name);
   }
 
   @Override protected void onSaveInstanceState(Bundle outState) {

--- a/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
+++ b/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
@@ -18,8 +18,6 @@ package com.example.mortar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.ViewGroup;
 import android.util.Log;
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockActivity;
@@ -46,7 +44,6 @@ import static android.view.MenuItem.SHOW_AS_ACTION_ALWAYS;
  */
 public class DemoActivity extends SherlockActivity implements ActionBarOwner.View {
   private MortarActivityScope activityScope;
-  private Context mortarContext;
   private ActionBarOwner.MenuAction actionBarMenuAction;
 
   @Inject ActionBarOwner actionBarOwner;
@@ -60,10 +57,9 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
       return;
     }
 
-    MortarScope parentScope = ((DemoApplication) getApplication()).getRootScope();
+    MortarScope parentScope = Mortar.getScope(getApplication());
     activityScope = Mortar.requireActivityScope(parentScope, new Main());
-    mortarContext = activityScope.createContext(this);
-    Mortar.inject(mortarContext, this);
+    Mortar.inject(this, this);
 
     activityScope.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
@@ -73,10 +69,11 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
     actionBarOwner.takeView(this);
   }
 
-  @Override public void setContentView(int layoutResId) {
-    LayoutInflater inflater =
-        (LayoutInflater) mortarContext.getSystemService(LAYOUT_INFLATER_SERVICE);
-    inflater.inflate(layoutResId, (ViewGroup) findViewById(android.R.id.content));
+  @Override public Object getSystemService(String name) {
+    if (Mortar.isScopeSystemService(name)) {
+      return activityScope;
+    }
+    return super.getSystemService(name);
   }
 
   @Override protected void onSaveInstanceState(Bundle outState) {
@@ -134,7 +131,7 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
   }
 
   @Override public Context getMortarContext() {
-    return mortarContext;
+    return this;
   }
 
   @Override public void setShowHomeEnabled(boolean enabled) {

--- a/mortar-sample/src/main/java/com/example/mortar/DemoApplication.java
+++ b/mortar-sample/src/main/java/com/example/mortar/DemoApplication.java
@@ -40,7 +40,10 @@ public class DemoApplication extends Application {
         Mortar.createRootScope(BuildConfig.DEBUG, ObjectGraph.create(new ApplicationModule()));
   }
 
-  public MortarScope getRootScope() {
-    return rootScope;
+  @Override public Object getSystemService(String name) {
+    if (Mortar.isScopeSystemService(name)) {
+      return rootScope;
+    }
+    return super.getSystemService(name);
   }
 }

--- a/mortar/src/main/java/mortar/Mortar.java
+++ b/mortar/src/main/java/mortar/Mortar.java
@@ -20,10 +20,11 @@ import android.content.Context;
 import dagger.ObjectGraph;
 
 import static java.lang.String.format;
-import static mortar.MortarContextWrapper.MORTAR_SCOPE_SERVICE;
 
 /** Provides static bootstrap and integration methods. */
 public class Mortar {
+
+  static final String MORTAR_SCOPE_SERVICE = "mortar_scope";
 
   private Mortar() {
   }
@@ -85,10 +86,19 @@ public class Mortar {
   public static MortarScope getScope(Context context) {
     MortarScope scope = (MortarScope) context.getSystemService(MORTAR_SCOPE_SERVICE);
     if (scope == null) {
-      throw new IllegalArgumentException(
-          format("Cannot find scope in %s.  Make sure your Activity's content view is set using "
-              + " an inflater from MortarScope.createContext()", context.getClass().getName()));
+      throw new IllegalArgumentException(format(
+          "Cannot find scope in %s. Make sure your Activity overrides getSystemService() "
+              + " to return its scope if isScopeSystemService() is true",
+          context.getClass().getName()));
     }
     return scope;
+  }
+
+  /**
+   * Use this when overriding {@link android.app.Activity#getSystemService(String)}. If this
+   * returns true, you should return the activity scope from there.
+   */
+  public static boolean isScopeSystemService(String name) {
+    return MORTAR_SCOPE_SERVICE.equals(name);
   }
 }

--- a/mortar/src/main/java/mortar/MortarContextWrapper.java
+++ b/mortar/src/main/java/mortar/MortarContextWrapper.java
@@ -22,8 +22,6 @@ import android.view.LayoutInflater;
 class MortarContextWrapper extends ContextWrapper {
   private final MortarScope scope;
 
-  static final String MORTAR_SCOPE_SERVICE = "mortar_scope";
-
   private LayoutInflater inflater;
 
   public MortarContextWrapper(Context context, MortarScope scope) {
@@ -32,7 +30,7 @@ class MortarContextWrapper extends ContextWrapper {
   }
 
   @Override public Object getSystemService(String name) {
-    if (MORTAR_SCOPE_SERVICE.equals(name)) {
+    if (Mortar.isScopeSystemService(name)) {
       return scope;
     }
     if (LAYOUT_INFLATER_SERVICE.equals(name)) {
@@ -41,7 +39,6 @@ class MortarContextWrapper extends ContextWrapper {
       }
       return inflater;
     }
-
     return super.getSystemService(name);
   }
 }

--- a/mortar/src/test/java/mortar/MortarScopeTest.java
+++ b/mortar/src/test/java/mortar/MortarScopeTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import static dagger.ObjectGraph.create;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Arrays.asList;
+import static mortar.Mortar.MORTAR_SCOPE_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
@@ -514,7 +515,7 @@ public class MortarScopeTest {
   @Test
   public void inject() {
     MortarScope root = Mortar.createRootScope(false, create(new Able()));
-    when(context.getSystemService(MortarContextWrapper.MORTAR_SCOPE_SERVICE)).thenReturn(root);
+    when(context.getSystemService(MORTAR_SCOPE_SERVICE)).thenReturn(root);
     HasApple apple = new HasApple();
     Mortar.inject(context, apple);
     assertThat(apple.string).isEqualTo(Apple.class.getName());
@@ -523,7 +524,7 @@ public class MortarScopeTest {
   @Test
   public void getScope() {
     MortarScope root = Mortar.createRootScope(false, create(new Able()));
-    when(context.getSystemService(MortarContextWrapper.MORTAR_SCOPE_SERVICE)).thenReturn(root);
+    when(context.getSystemService(MORTAR_SCOPE_SERVICE)).thenReturn(root);
     assertThat(Mortar.getScope(context)).isSameAs(root);
   }
 

--- a/mortar/src/test/java/mortar/MortarTest.java
+++ b/mortar/src/test/java/mortar/MortarTest.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static mortar.MortarContextWrapper.MORTAR_SCOPE_SERVICE;
+import static mortar.Mortar.MORTAR_SCOPE_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Building on top of #70, which brought the great idea of using system services.
- Overriding `setContentView()` and manually inflating was not a good idea. It broke ActionBarSherlock support. It also created a useless extra context wrapper, for the sole purpose of providing the activity scope.
- Instead we let the activity provide the scope as a system service. Same goes for the application. More decoupling ensues.
- I also cleaned a few places in the doc that were leftovers from the `MortarContext` times.
