### PR TITLE
Remove old view and destroy scope concurrently in sample.

### DIFF
--- a/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
+++ b/mortar-sample/src/main/java/com/example/mortar/DemoActivity.java
@@ -48,6 +48,7 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
 
   @Inject ActionBarOwner actionBarOwner;
   private Flow mainFlow;
+  private MainView mainView;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -63,7 +64,7 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
 
     activityScope.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
-    MainView mainView = (MainView) findViewById(R.id.container);
+    mainView = (MainView) findViewById(R.id.container);
     mainFlow = mainView.getFlow();
 
     actionBarOwner.takeView(this);
@@ -128,6 +129,7 @@ public class DemoActivity extends SherlockActivity implements ActionBarOwner.Vie
       MortarScope parentScope = Mortar.getScope(getApplication());
       parentScope.destroyChild(activityScope);
       activityScope = null;
+      mainView.onScopeDestroyed();
     }
   }
 

--- a/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
+++ b/mortar-sample/src/main/java/com/example/mortar/core/MainView.java
@@ -47,4 +47,13 @@ public class MainView extends FrameLayout implements CanShowScreen<Blueprint> {
   @Override public void showScreen(Blueprint screen, Flow.Direction direction) {
     screenMaestro.showScreen(screen, direction);
   }
+
+  public void onScopeDestroyed() {
+    screenMaestro.onScopeDestroyed();
+  }
+  
+  @Override protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    screenMaestro.onContainerDetached();
+  }
 }


### PR DESCRIPTION
In the ScreenConductor, synchronize view and scope destruction by destroying old child scope when the out animation has finished. NOTE: I still measured a 30ms delay between onAnimationEnd and onDetachFromWindow for the oldView
