### PR TITLE
Two service locator fixes

### DIFF
--- a/mortar/src/main/java/mortar/MortarScope.java
+++ b/mortar/src/main/java/mortar/MortarScope.java
@@ -27,7 +27,7 @@ import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
 
 public class MortarScope {
-  public static final String DIVIDER = ":";
+  public static final String DIVIDER = ">>>";
   public static final String ROOT_NAME = "Root";
   public static final String SERVICE_NAME = MortarScope.class.getName();
 
@@ -72,7 +72,7 @@ public class MortarScope {
 
   public String getPath() {
     if (parent == null) return getName();
-    return parent.getPath() + ":" + getName();
+    return parent.getPath() + DIVIDER + getName();
   }
 
   public boolean hasService(String serviceName) {

--- a/mortar/src/main/java/mortar/bundler/BundleServiceRunner.java
+++ b/mortar/src/main/java/mortar/bundler/BundleServiceRunner.java
@@ -2,7 +2,9 @@ package mortar.bundler;
 
 import android.content.Context;
 import android.os.Bundle;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -77,9 +79,17 @@ public class BundleServiceRunner {
     rootBundle = outState;
 
     state = State.SAVING;
-    for (Map.Entry<String, BundleService> entry : scopedServices.entrySet()) {
-      entry.getValue().saveToRootBundle(rootBundle);
+
+    // Make a dwindling copy of the services, in case one is deleted as a side effect
+    // of another's onSave.
+    List<Map.Entry<String, BundleService>> servicesToBeSaved =
+        new ArrayList<>(scopedServices.entrySet());
+
+    while (!servicesToBeSaved.isEmpty()) {
+      Map.Entry<String, BundleService> entry = servicesToBeSaved.remove(0);
+      if (scopedServices.containsKey(entry.getKey())) entry.getValue().saveToRootBundle(rootBundle);
     }
+
     state = State.IDLE;
   }
 


### PR DESCRIPTION
 1. Make the scope path separator a bit more obscure, less like to conflict w/custom names
 2. Allow calls from Bundler#onSave to MortarScope#destroy