### PR TITLE
Allow services to be scoped.

### DIFF
--- a/dagger1support/src/test/java/mortar/MortarActivityScopeTest.java
+++ b/dagger1support/src/test/java/mortar/MortarActivityScopeTest.java
@@ -122,10 +122,15 @@ public class MortarActivityScopeTest {
 
   /** Simulate a new proecess by creating brand new scope instances. */
   private void newProcess() {
+    newProcess("activity");
+  }
+
+  private void newProcess(String activityScopeName) {
     MortarScope root = MortarScope.buildRootScope()
         .withService(ObjectGraphService.SERVICE_NAME, ObjectGraph.create(new MyModule()))
         .build();
-    activityScope = ObjectGraphService.requireActivityScope(root, new MyBlueprint("activity"));
+    activityScope =
+        ObjectGraphService.requireActivityScope(root, new MyBlueprint(activityScopeName));
   }
 
   @Test(expected = IllegalArgumentException.class) public void nonNullKeyRequired() {
@@ -232,7 +237,10 @@ public class MortarActivityScopeTest {
 
     // Process death: new copy of the bundle, new scope and activity instances
     bundle = new Bundle(bundle);
-    newProcess();
+
+    // Activity scopes often include transient values like task id. Make sure
+    // BundlerServiceRunner isn't stymied by that.
+    newProcess("anotherActivity");
     activity = new FauxActivity();
     activity.create(bundle);
     assertThat(activity.rootBundler.lastLoaded).isNotNull();

--- a/mortar/src/main/java/mortar/MortarScope.java
+++ b/mortar/src/main/java/mortar/MortarScope.java
@@ -204,6 +204,11 @@ public class MortarScope {
       this.parent = parent;
     }
 
+    /**
+     * Makes this service available via the new scope's {@link MortarScope#findService}
+     * method. If the service implements {@link Scoped} it will be registered with
+     * the new scope.
+     */
     public Builder withService(String serviceName, Object service) {
       Object existing = serviceProviders.put(serviceName, service);
       if (existing != null) {
@@ -218,6 +223,10 @@ public class MortarScope {
       MortarScope newScope = new MortarScope(name, parent, serviceProviders);
       if (parent != null) {
         parent.children.put(name, newScope);
+      }
+
+      for (Object service : serviceProviders.values()) {
+        if (service instanceof Scoped) newScope.register((Scoped) service);
       }
       return newScope;
     }

--- a/mortar/src/main/java/mortar/bundler/BundleService.java
+++ b/mortar/src/main/java/mortar/bundler/BundleService.java
@@ -80,12 +80,12 @@ public class BundleService {
   void init() {
     scope.register(new Scoped() {
       @Override public void onEnterScope(MortarScope scope) {
-        runner.scopedServices.put(scope.getPath(), BundleService.this);
+        runner.scopedServices.put(runner.bundleKey(scope), BundleService.this);
       }
 
       @Override public void onExitScope() {
         for (Bundler b : bundlers) b.onExitScope();
-        runner.scopedServices.remove(scope.getPath());
+        runner.scopedServices.remove(runner.bundleKey(scope));
         runner.servicesToBeLoaded.remove(BundleService.this);
       }
     });
@@ -112,15 +112,16 @@ public class BundleService {
   }
 
   private Bundle findScopeBundle(Bundle root) {
-    return root == null ? null : root.getBundle(scope.getPath());
+    return root == null ? null : root.getBundle(runner.bundleKey(scope));
   }
 
   void saveToRootBundle(Bundle rootBundle) {
-    scopeBundle = rootBundle.getBundle(scope.getPath());
+    String key = runner.bundleKey(scope);
+    scopeBundle = rootBundle.getBundle(key);
 
     if (scopeBundle == null) {
       scopeBundle = new Bundle();
-      rootBundle.putBundle(scope.getPath(), scopeBundle);
+      rootBundle.putBundle(key, scopeBundle);
     }
 
     for (Bundler bundler : bundlers) {


### PR DESCRIPTION
BundleServiceRunner uses this to minimize the keys it writes
to the bundle, thus keeping it safe for apps to use crazy
transient values like task-id in their activity scope names.