### PR TITLE
Avoid memory leak in sample

### DIFF
--- a/mortar-sample/src/main/java/com/example/mortar/core/MortarDemoActivity.java
+++ b/mortar-sample/src/main/java/com/example/mortar/core/MortarDemoActivity.java
@@ -163,6 +163,7 @@ public class MortarDemoActivity extends android.app.Activity
 
   @Override protected void onDestroy() {
     actionBarOwner.dropView(this);
+    actionBarOwner.setConfig(null);
 
     // activityScope may be null in case isWrongInstance() returned true in onCreate()
     if (isFinishing() && activityScope != null) {


### PR DESCRIPTION
ActionBarOwner is Application-wide singleton, it's assigned config with anonymous Action0 which will hold ref. to outer class (activity). So, exiting activity won't destroy it due to owner holding ref to config holding ref to action holding ref to activity.