### PR TITLE
Avoid unnecessary method traversing for DaggerService

### DIFF
--- a/dagger2support/src/main/java/mortar/dagger2support/DaggerService.java
+++ b/dagger2support/src/main/java/mortar/dagger2support/DaggerService.java
@@ -30,7 +30,7 @@ public class DaggerService {
       Class<?> generatedClass = Class.forName(generatedName);
       Object builder = generatedClass.getMethod("builder").invoke(null);
 
-      for (Method method : builder.getClass().getMethods()) {
+      for (Method method : builder.getClass().getDeclaredMethods()) {
         Class<?>[] params = method.getParameterTypes();
         if (params.length == 1) {
           Class<?> dependencyClass = params[0];


### PR DESCRIPTION
Traverse through declared methods only to avoid clashes with java base methods like equals, etc.