### PR TITLE
fix(MortarScope) use application context in MortarScope#getScope()

### DIFF
--- a/mortar/src/main/java/mortar/MortarScope.java
+++ b/mortar/src/main/java/mortar/MortarScope.java
@@ -31,7 +31,8 @@ public class MortarScope {
   public static final String SERVICE_NAME = MortarScope.class.getName();
 
   public static MortarScope getScope(Context context) {
-    return (MortarScope) context.getSystemService(MortarScope.SERVICE_NAME);
+    final Context application = context.getApplicationContext();
+    return (MortarScope) application.getSystemService(MortarScope.SERVICE_NAME);
   }
 
   public static MortarScope findChild(Context context, String name) {


### PR DESCRIPTION
Hi! I suggest to use application context in ```MortarScope.getScope()```.
In our activities we call ```MortarScope.findChild(context)``` and ```MortarScope.buildChild(context)```. Every time we must pass the ```getApplicationContext()``` as a parameter. I found that if developer forgets about it and accidentally passes ```this``` (current ```Activity``` instance), he'll get the ```StackOverflowException``` because of recursive function call. To avoid this I propose my solution that ensures we'll always have correct context for getting system service by name.