### PR TITLE
Change generated name to be consistent with Dagger 2

### DIFF
--- a/dagger2support/src/main/java/mortar/dagger2support/DaggerService.java
+++ b/dagger2support/src/main/java/mortar/dagger2support/DaggerService.java
@@ -24,7 +24,7 @@ public class DaggerService {
     String packageName = componentClass.getPackage().getName();
     // Accounts for inner classes, ie MyApplication$Component
     String simpleName = fqn.substring(packageName.length() + 1);
-    String generatedName = (packageName + ".Dagger_" + simpleName).replace('$', '_');
+    String generatedName = (packageName + ".Dagger" + simpleName).replace('$', '_');
 
     try {
       Class<?> generatedClass = Class.forName(generatedName);


### PR DESCRIPTION
Change the generated name to be able to use it with Dagger 2 (the release version, no snapshot).