### PR TITLE
fix(BundleServiceComparator): use ternary operator instead of Integer#compare() that requires API level 19

### DIFF
--- a/mortar/src/main/java/mortar/bundler/BundleServiceComparator.java
+++ b/mortar/src/main/java/mortar/bundler/BundleServiceComparator.java
@@ -9,7 +9,7 @@ class BundleServiceComparator implements Comparator<BundleService> {
     String[] rightPath = right.scope.getPath().split(MortarScope.DIVIDER);
 
     if (leftPath.length != rightPath.length) {
-      return Integer.compare(leftPath.length, rightPath.length);
+      return leftPath.length < rightPath.length ? -1 : 1;
     }
 
     int segments = leftPath.length;


### PR DESCRIPTION
Hi! I suggest to replace ```Integer.compare``` with ternary operator:
* That method added in API level 19 but Mortar supports much lower API versions;
* Since in this block array lengths are different, so result can be only 1 or -1 and now it's more obvious for reading.