### PR TITLE
Throw valid exceptions on service lookup and build

### DIFF
--- a/dagger1support/src/test/java/mortar/MortarScopeTest.java
+++ b/dagger1support/src/test/java/mortar/MortarScopeTest.java
@@ -264,10 +264,10 @@ import static org.mockito.MockitoAnnotations.initMocks;
     root.destroy();
     verify(scoped).onExitScope();
 
-    IllegalArgumentException caught = null;
+    IllegalStateException caught = null;
     try {
       getObjectGraph(activityScope);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       caught = e;
     }
     assertThat(caught).isNotNull();
@@ -367,10 +367,10 @@ import static org.mockito.MockitoAnnotations.initMocks;
     root.destroy();
     verify(scoped).onExitScope();
 
-    IllegalArgumentException caught = null;
+    IllegalStateException caught = null;
     try {
       assertThat(getObjectGraph(child)).isNull();
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       caught = e;
     }
     assertThat(caught).isNotNull();
@@ -467,10 +467,10 @@ import static org.mockito.MockitoAnnotations.initMocks;
     MortarScope scope = createRootScope(create(new Able()));
     scope.destroy();
 
-    IllegalArgumentException caught = null;
+    IllegalStateException caught = null;
     try {
       getObjectGraph(scope);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       caught = e;
     }
     assertThat(caught).isNotNull();

--- a/mortar/src/main/java/mortar/MortarScope.java
+++ b/mortar/src/main/java/mortar/MortarScope.java
@@ -74,6 +74,10 @@ public class MortarScope {
     return parent.getPath() + DIVIDER + getName();
   }
 
+  /**
+   * Returns true if the service associated with the given name is available &
+   * if the scope is not destroyed
+   */
   public boolean hasService(String serviceName) {
     return !isDestroyed() && findService(serviceName) != null;
   }
@@ -95,14 +99,13 @@ public class MortarScope {
 
   @SuppressWarnings("unchecked") //
   private <T> T findService(String serviceName) {
-    if (!isDestroyed()) {
-      if (SERVICE_NAME.equals(serviceName)) return (T) this;
+    assertNotDead();
+    if (SERVICE_NAME.equals(serviceName)) return (T) this;
 
-      T service = (T) services.get(serviceName);
-      if (service != null) return service;
+    T service = (T) services.get(serviceName);
+    if (service != null) return service;
 
-      if (parent != null) return parent.findService(serviceName);
-    }
+    if (parent != null) return parent.findService(serviceName);
 
     return null;
   }
@@ -195,11 +198,6 @@ public class MortarScope {
      * method.
      */
     public Builder withService(String serviceName, Object service) {
-      if (service instanceof Scoped) {
-        throw new IllegalArgumentException(String.format(
-            "For service %s, %s must not be an instance of %s, use \"withScopedService\" instead.",
-            serviceName, service, Scoped.class.getSimpleName()));
-      }
       return doWithService(serviceName, service);
     }
 
@@ -237,10 +235,14 @@ public class MortarScope {
 
     private Builder doWithService(String serviceName, Object service) {
       Object existing = serviceProviders.put(serviceName, service);
+      if (service == null) {
+        throw new NullPointerException("service == null");
+      }
       if (existing != null) {
         throw new IllegalArgumentException(
-            format("Scope builder already bound to service %s, cannot be rebound to %s",
-                existing, service));
+            format(
+                "Scope builder already bound \"%s\" to service \"%s\", cannot be rebound to \"%s\"",
+                serviceName, existing.getClass().getName(), service.getClass().getName()));
       }
       return this;
     }

--- a/mortar/src/main/java/mortar/MortarScope.java
+++ b/mortar/src/main/java/mortar/MortarScope.java
@@ -198,6 +198,11 @@ public class MortarScope {
      * method.
      */
     public Builder withService(String serviceName, Object service) {
+      if (service instanceof Scoped) {
+        throw new IllegalArgumentException(String.format(
+            "For service %s, %s must not be an instance of %s, use \"withScopedService\" instead.",
+            serviceName, service, Scoped.class.getSimpleName()));
+      }
       return doWithService(serviceName, service);
     }
 

--- a/mortar/src/test/java/mortar/MortarScopeTest.java
+++ b/mortar/src/test/java/mortar/MortarScopeTest.java
@@ -1,0 +1,116 @@
+package mortar;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static mortar.MortarScope.DIVIDER;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class MortarScopeTest {
+  MortarScope.Builder scopeBuilder;
+
+  @Before public void setUp() {
+    scopeBuilder = MortarScope.buildRootScope();
+  }
+
+  @Test public void illegalScopeName() {
+    try {
+      scopeBuilder.build("Root" + DIVIDER);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageContaining("must not contain");
+    }
+  }
+
+  @Test public void noServiceRebound() {
+    scopeBuilder.withService("ServiceName", new Object());
+    try {
+      scopeBuilder.withService("ServiceName", new Object());
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageContaining("cannot be rebound");
+    }
+  }
+
+  @Test public void nullServiceBound() {
+    try {
+      scopeBuilder.withService("ServiceName", null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("service == null");
+    }
+  }
+
+  @Test public void buildScopeWithChild() {
+    MortarScope rootScope = scopeBuilder.build("Root");
+    MortarScope childScope = rootScope.buildChild().build("Child");
+    assertThat(rootScope.children.size()).isEqualTo(1);
+    assertThat(childScope.parent).isEqualTo(rootScope);
+    assertThat(childScope.getPath()).isEqualTo("Root" + DIVIDER + "Child");
+  }
+
+  @Test public void findParentServiceFromChildScope() {
+    Object dummyService = new Object();
+    MortarScope rootScope = scopeBuilder.withService("ServiceOne", dummyService).build("Root");
+    MortarScope childScope = rootScope.buildChild().build("Child");
+    assertThat(childScope.getService("ServiceOne")).isEqualTo(dummyService);
+  }
+
+  @Test public void noChildrenWithSameName() {
+    MortarScope rootScope = scopeBuilder.build("Root");
+    rootScope.buildChild().build("childOne");
+    try {
+      rootScope.buildChild().build("childOne");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageContaining("already has a child named");
+    }
+  }
+
+  @Test public void throwIfNoServiceFoundForGivenName() {
+    Object dummyService = new Object();
+    MortarScope rootScope = scopeBuilder.withService("ServiceOne", dummyService).build("Root");
+    assertThat(rootScope.getService("ServiceOne")).isNotNull();
+    try {
+      rootScope.getService("SearchThis");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("No service found named \"SearchThis\"");
+    }
+  }
+
+  @Test public void throwIfFindChildAfterDestroyed() {
+    MortarScope rootScope = scopeBuilder.build("Root");
+    MortarScope childScope = rootScope.buildChild().build("ChildOne");
+
+    assertThat(rootScope.findChild("ChildOne")).isNotNull().isEqualTo(childScope);
+
+    rootScope.destroy();
+    assertThat(childScope.isDestroyed()).isTrue();
+    assertThat(rootScope.isDestroyed()).isTrue();
+
+    try {
+      rootScope.findChild("ChildOne");
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageContaining("destroyed");
+    }
+  }
+
+  @Test public void throwIfFindServiceAfterDestroyed() {
+    Object dummyService = new Object();
+    MortarScope rootScope = scopeBuilder.withService("ServiceOne", dummyService).build("Root");
+    assertThat(rootScope.getService("ServiceOne")).isEqualTo(dummyService);
+
+    rootScope.destroy();
+    assertThat(rootScope.isDestroyed()).isTrue();
+
+    try {
+      rootScope.getService("ServiceOne");
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessageContaining("destroyed");
+    }
+  }
+}


### PR DESCRIPTION
`MortarScope#getService` to throw IllegalStateException if called after scope is destroyed
Null check before mapping service in a scope fixes #151
Add unit tests for MortarScope Builder