### PR TITLE
fix scope name collision problem

### DIFF
--- a/mortar-sample/src/main/java/com/example/mortar/mortarflow/MortarContextFactory.java
+++ b/mortar-sample/src/main/java/com/example/mortar/mortarflow/MortarContextFactory.java
@@ -16,7 +16,7 @@ public final class MortarContextFactory implements PathContextFactory {
 
   @Override public Context setUpContext(Path path, Context parentContext) {
     MortarScope screenScope =
-        screenScoper.getScreenScope(parentContext, path.getClass().getName(), path);
+        screenScoper.getScreenScope(parentContext, path.toString(), path);
     return new TearDownContext(parentContext, screenScope);
   }
 


### PR DESCRIPTION
Issue #149 is due to use flow to set multiple FriendListScreens. But each FriendListScreen has the same scope name, so the scope might be destroyed after you enter next FriendListScreen.
This pull request use the object instance name as scope name rather than use class name should fix the problem.