### PR TITLE
fix lint checks by reverting to 1.2.3 plugin (1.3.1 and 1.5.0 are bad)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext.deps = [
-    android_gradle_plugin      : 'com.android.tools.build:gradle:1.3.1',
+    android_gradle_plugin      : 'com.android.tools.build:gradle:1.2.3',
 ]
 
 ext.minSdkVersion = 14

--- a/mortar-dagger1/src/main/java/mortar/dagger1support/ObjectGraphService.java
+++ b/mortar-dagger1/src/main/java/mortar/dagger1support/ObjectGraphService.java
@@ -23,6 +23,7 @@ public class ObjectGraphService {
   }
 
   public static ObjectGraph getObjectGraph(Context context) {
+    //noinspection ResourceType
     return (ObjectGraph) context.getSystemService(ObjectGraphService.SERVICE_NAME);
   }
 


### PR DESCRIPTION
The command `./gradlew clean build check` needs to pass without errors.